### PR TITLE
Build with full rust installer + changed example to use localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ OPTIONS:
     -n, --n_threads <n-threads>    Number of Spammer Threads [default: 1]
     -t, --timeout <timeout>        Set Timeout (seconds) [default: 500]
     -u, --url <url>                Node URL [default: http://api.hornet-1.testnet.chrysalis2.com]
+                                   (Note: You might need to specify the api port e.g. <URL>:14265)
 ```
 
 ```
-$ cargo run --release -- -n 3 -m 32 -i rspammer_index -u http://127.0.0.1:14265
+$ cargo run --release -- -n 3 -m 32 -i rspammer_index -u http://api.hornet-1.testnet.chrysalis2.com/
 Starting iota_rspammer with the following parameters:
 message payload size: 32 bytes
 message index: rspammer_index
-node url: http://127.0.0.1:14265/
+node url: http://api.hornet-1.testnet.chrysalis2.com//
 local PoW: false
 
 Created IOTA Client 1.

--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ Provides insight into underlying statistical patterns of the protocol from the p
 
 ## Build
 ```
-$ sudo apt-get install libgsl0-dev cargo pkg-config libssl-dev
+$ sudo apt-get install libgsl0-dev pkg-config libssl-dev
+$ sudo curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 $ git clone https://github.com/bernardoaraujor/iota_rspammer.git
 $ cd iota_rspammer
-$ cargo build
+$ cargo build --release
 ```
 
 ## Run
 ```
-$ cargo run -- -h
+$ cargo run --release -h
 iota_rspammer 0.1.1
 
 USAGE:
@@ -48,11 +49,11 @@ OPTIONS:
 ```
 
 ```
-$ cargo run -- -n 3 -m 32 -i rspammer_index -u http://api.hornet-1.testnet.chrysalis2.com/
+$ cargo run --release -- -n 3 -m 32 -i rspammer_index -u http://127.0.0.1:14265
 Starting iota_rspammer with the following parameters:
 message payload size: 32 bytes
 message index: rspammer_index
-node url: http://api.hornet-1.testnet.chrysalis2.com/
+node url: http://127.0.0.1:14265/
 local PoW: false
 
 Created IOTA Client 1.


### PR DESCRIPTION
Should fix [this issue](https://github.com/bernardoaraujor/iota_rspammer/issues/4#issue-818649813).

The rustc version coming with apt-install cargo will not compile successfully while the most recent version (1.50.0 as of now) will. I also changed the readme to show compiling with the --release flag.