### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iota-core = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
+iota-client = { git = "https://github.com/iotaledger/iota.rs", branch = "dev" }
+bee-message = { git = "https://github.com/iotaledger/bee", branch = "dev" }
 tokio = { version = "1.0", features = ["macros", "sync", "time"] }
 structopt = { version = "0.3", default-features = false }
 url = "2.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use iota::{Api, Client};
+use iota_client::{Api, Client};
 use rand::Rng;
 use std::time::{Duration, Instant};
 use structopt::StructOpt;
@@ -56,7 +56,7 @@ struct Opt {
 #[derive(Debug)]
 struct MsgResult {
     thread_n: u32,
-    msg: iota::MessageId,
+    msg: bee_message::MessageId,
     confirmation_t: Duration,
 }
 


### PR DESCRIPTION
This PR fixes issues related to pulling dependencies. IOTA renamed their client package and moved DTOs to bee repository into bee-message package.

Regarding functionality, nothing is changed.